### PR TITLE
Add bike ad collector with RSS ingestion and Playwright enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
+# eBay Kleinanzeigen Bike Ads Collector
 
+This project polls public RSS feeds from [eBay Kleinanzeigen](https://www.kleinanzeigen.de/) to collect
+second-hand bike advertisements. Ads are stored in a SQLite database and can be
+optionally enriched with additional details using Playwright.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+# Playwright needs browsers:
+playwright install
+```
+
+Edit `config.toml` and add the RSS feed URLs you want to monitor.
+
+## Usage
+
+### Ingest RSS feeds
+
+```bash
+python rss_ingest.py
+```
+
+The script runs continuously and polls the configured feeds every
+`poll_interval_minutes`. New ads are inserted into the database and existing
+ones are updated. Ads not seen in the latest poll are marked inactive.
+
+### Enrich ads with Playwright
+
+```bash
+python enrich_playwright.py <ad_url> [<ad_url> ...]
+```
+
+For each provided ad URL, the script downloads the full description, price,
+location, date string, and main image and updates the corresponding record in
+the database. Requests are throttled and a custom User-Agent is used.
+
+## Modules
+
+* `model.py` – Dataclass representing an ad.
+* `db.py` – SQLite helper functions.
+* `de_dates.py` – Parse German relative dates to ISO format.
+* `rss_ingest.py` – Poll RSS feeds and store ads.
+* `enrich_playwright.py` – Enrich ads by visiting the ad page.
+
+## Schema
+
+The SQLite database contains a single table `ads` with the columns:
+
+```
+id TEXT PRIMARY KEY
+title TEXT
+price INTEGER
+location TEXT
+date_posted TEXT
+link TEXT
+image TEXT
+body_text TEXT
+first_seen TEXT
+last_seen TEXT
+is_active INTEGER
+```
+
+## License
+
+MIT

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,8 @@
+# Configuration for RSS ingestion
+poll_interval_minutes = 15
+feeds = [
+    "https://www.kleinanzeigen.de/s-fahrrader/kleinanzeigen/c216",
+    # Add more feed URLs here
+]
+# Optional: path to database file
+# database = "ads.db"

--- a/db.py
+++ b/db.py
@@ -1,0 +1,115 @@
+"""SQLite database helpers for storing ads."""
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable, Optional
+
+from model import Ad
+
+DATABASE_FILE = "ads.db"
+
+
+def get_connection(path: str = DATABASE_FILE) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ads (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            price INTEGER,
+            location TEXT,
+            date_posted TEXT,
+            link TEXT,
+            image TEXT,
+            body_text TEXT,
+            first_seen TEXT,
+            last_seen TEXT,
+            is_active INTEGER
+        )
+        """
+    )
+    conn.commit()
+
+
+def upsert_ad(conn: sqlite3.Connection, ad: Ad) -> None:
+    existing = conn.execute("SELECT id FROM ads WHERE id = ?", (ad.id,)).fetchone()
+    if existing:
+        conn.execute(
+            """
+            UPDATE ads
+            SET title = ?, price = ?, location = ?, date_posted = ?, link = ?, image = ?,
+                last_seen = ?, is_active = 1
+            WHERE id = ?
+            """,
+            (
+                ad.title,
+                ad.price,
+                ad.location,
+                ad.date_posted,
+                ad.link,
+                ad.image,
+                ad.last_seen,
+                ad.id,
+            ),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT INTO ads (
+                id, title, price, location, date_posted, link, image, body_text,
+                first_seen, last_seen, is_active
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                ad.id,
+                ad.title,
+                ad.price,
+                ad.location,
+                ad.date_posted,
+                ad.link,
+                ad.image,
+                ad.body_text,
+                ad.first_seen,
+                ad.last_seen,
+                int(ad.is_active),
+            ),
+        )
+    conn.commit()
+
+
+def mark_inactive(conn: sqlite3.Connection, cutoff: str) -> None:
+    """Mark ads as inactive if they haven't been seen since cutoff."""
+    conn.execute(
+        "UPDATE ads SET is_active = 0 WHERE last_seen < ?", (cutoff,)
+    )
+    conn.commit()
+
+
+def update_details(
+    conn: sqlite3.Connection,
+    ad_id: str,
+    *,
+    price: Optional[int] = None,
+    location: Optional[str] = None,
+    date_posted: Optional[str] = None,
+    image: Optional[str] = None,
+    body_text: Optional[str] = None,
+) -> None:
+    conn.execute(
+        """
+        UPDATE ads
+        SET price = COALESCE(?, price),
+            location = COALESCE(?, location),
+            date_posted = COALESCE(?, date_posted),
+            image = COALESCE(?, image),
+            body_text = COALESCE(?, body_text)
+        WHERE id = ?
+        """,
+        (price, location, date_posted, image, body_text, ad_id),
+    )
+    conn.commit()

--- a/de_dates.py
+++ b/de_dates.py
@@ -1,0 +1,41 @@
+"""Utilities for parsing German relative dates into ISO format."""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+def parse_de_relative_date(text: str, *, now: Optional[datetime] = None) -> Optional[str]:
+    """Convert German date expressions like 'Heute', 'Gestern', 'vor X Tagen'
+    into ISO date strings (YYYY-MM-DD).
+
+    Returns ``None`` if the text cannot be parsed.
+    """
+    if now is None:
+        now = datetime.now()
+
+    t = text.strip().lower()
+    if not t:
+        return None
+
+    if t.startswith("heute"):
+        dt = now
+    elif t.startswith("gestern"):
+        dt = now - timedelta(days=1)
+    else:
+        m = re.search(r"vor\s+(\d+)\s+tag", t)
+        if m:
+            days = int(m.group(1))
+            dt = now - timedelta(days=days)
+        else:
+            # try dd.mm.yyyy or ISO date
+            for fmt in ("%d.%m.%Y", "%Y-%m-%d"):
+                try:
+                    dt = datetime.strptime(t, fmt)
+                    break
+                except ValueError:
+                    continue
+            else:
+                return None
+    return dt.date().isoformat()

--- a/enrich_playwright.py
+++ b/enrich_playwright.py
@@ -1,0 +1,80 @@
+"""Enrich ads by visiting the ad page with Playwright."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+from typing import Iterable
+
+from bs4 import BeautifulSoup
+from playwright.async_api import async_playwright
+
+from db import get_connection, update_details
+from de_dates import parse_de_relative_date
+
+USER_AGENT = "Mozilla/5.0 (compatible; KleinanzeigenBot/1.0; +https://example.com)"
+THROTTLE_SECONDS = 2
+
+
+def extract_details(html: str) -> dict:
+    soup = BeautifulSoup(html, "html.parser")
+    body = soup.select_one("#viewad-description-text")
+    body_text = body.get_text(" ", strip=True) if body else None
+
+    price = None
+    price_el = soup.select_one("[itemprop='price'], #viewad-price, .price")
+    if price_el:
+        text = price_el.get_text(" ", strip=True)
+        m = re.search(r"(\d+[\.\d]*)\s*€", text)
+        if m:
+            price = int(m.group(1).replace(".", ""))
+
+    location = None
+    loc_el = soup.select_one("[itemprop='address'], .location, #viewad-locality")
+    if loc_el:
+        location = loc_el.get_text(" ", strip=True)
+
+    date_posted = None
+    date_el = soup.select_one("time, .date")
+    if date_el:
+        date_posted = parse_de_relative_date(date_el.get_text(" ", strip=True))
+
+    image = None
+    img_el = soup.select_one("img[itemprop='image'], #viewad-image img")
+    if img_el and img_el.get("src"):
+        image = img_el["src"]
+
+    return {
+        "price": price,
+        "location": location,
+        "date_posted": date_posted,
+        "image": image,
+        "body_text": body_text,
+    }
+
+
+async def enrich(urls: Iterable[str]) -> None:
+    conn = get_connection()
+    async with async_playwright() as p:
+        browser = await p.firefox.launch(headless=True)
+        context = await browser.new_context(user_agent=USER_AGENT)
+        page = await context.new_page()
+        for url in urls:
+            await page.goto(url, wait_until="domcontentloaded")
+            await asyncio.sleep(THROTTLE_SECONDS)
+            details = extract_details(await page.content())
+            ad_id = re.search(r"/(\d+)(?:\?|$)", url).group(1)
+            update_details(conn, ad_id, **details)
+        await browser.close()
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Enrich ads with Playwright")
+    parser.add_argument("urls", nargs="+", help="Ad URLs to enrich")
+    args = parser.parse_args()
+    asyncio.run(enrich(args.urls))
+
+
+if __name__ == "__main__":
+    main()

--- a/model.py
+++ b/model.py
@@ -1,0 +1,19 @@
+"""Data models for ads."""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Ad:
+    """Represents a single eBay Kleinanzeigen advertisement."""
+    id: str
+    title: str
+    price: Optional[int]
+    location: Optional[str]
+    date_posted: Optional[str]
+    link: str
+    image: Optional[str]
+    body_text: Optional[str]
+    first_seen: str
+    last_seen: str
+    is_active: bool = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+feedparser
+beautifulsoup4
+playwright

--- a/rss_ingest.py
+++ b/rss_ingest.py
@@ -1,0 +1,103 @@
+"""Poll RSS feeds and store ads in the database."""
+from __future__ import annotations
+
+import re
+import time
+from datetime import datetime
+from typing import Iterable, List, Set
+
+import feedparser
+from bs4 import BeautifulSoup
+
+try:  # Python 3.11+
+    import tomllib
+except Exception:  # pragma: no cover - fallback for older versions
+    import tomli as tomllib  # type: ignore
+
+from db import DATABASE_FILE, get_connection, init_db, mark_inactive, upsert_ad
+from de_dates import parse_de_relative_date
+from model import Ad
+
+CONFIG_FILE = "config.toml"
+
+
+def load_config(path: str = CONFIG_FILE) -> dict:
+    with open(path, "rb") as fh:
+        return tomllib.load(fh)
+
+
+def entry_to_ad(entry, now_iso: str) -> Ad:
+    link = entry.link
+    m = re.search(r"/(\d+)(?:\?|$)", link)
+    if not m:
+        raise ValueError(f"Cannot extract ID from link: {link}")
+    ad_id = m.group(1)
+    title = entry.get("title", "")
+    summary = entry.get("summary", "")
+    soup = BeautifulSoup(summary, "html.parser")
+    text = soup.get_text(" ", strip=True)
+    price_match = re.search(r"(\d+[\.\d]*)\s*€", text)
+    price = (
+        int(price_match.group(1).replace(".", "")) if price_match else None
+    )
+    location = None
+    loc = soup.find(class_="location")
+    if loc:
+        location = loc.get_text(strip=True)
+    published = entry.get("published")
+    date_posted = parse_de_relative_date(published) if published else None
+    image = None
+    media = entry.get("media_content") or entry.get("media_thumbnail")
+    if media:
+        image = media[0].get("url")
+    return Ad(
+        id=ad_id,
+        title=title,
+        price=price,
+        location=location,
+        date_posted=date_posted,
+        link=link,
+        image=image,
+        body_text=None,
+        first_seen=now_iso,
+        last_seen=now_iso,
+        is_active=True,
+    )
+
+
+def poll_once(feeds: Iterable[str], conn) -> int:
+    now_iso = datetime.utcnow().isoformat()
+    seen: Set[str] = set()
+    for url in feeds:
+        d = feedparser.parse(url)
+        for entry in d.entries:
+            try:
+                ad = entry_to_ad(entry, now_iso)
+            except Exception:
+                continue
+            seen.add(ad.id)
+            upsert_ad(conn, ad)
+    mark_inactive(conn, now_iso)
+    return len(seen)
+
+
+def main() -> None:
+    cfg = load_config()
+    feeds: List[str] = cfg.get("feeds", [])
+    interval = cfg.get("poll_interval_minutes", 15)
+    db_path = cfg.get("database", DATABASE_FILE)
+
+    conn = get_connection(db_path)
+    init_db(conn)
+
+    try:
+        while True:
+            count = poll_once(feeds, conn)
+            print(f"Polled {len(feeds)} feeds, seen {count} ads")
+            time.sleep(interval * 60)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add dataclass model for ads and SQLite helpers
- implement RSS polling with German date parsing
- enrich ads via Playwright with throttling
- provide config, requirements, and docs

## Testing
- `python -m py_compile model.py db.py de_dates.py rss_ingest.py enrich_playwright.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab57138664832ba59763cb6571521f