### PR TITLE
Add CSV export script with filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ For each provided ad URL, the script downloads the full description, price,
 location, date string, and main image and updates the corresponding record in
 the database. Requests are throttled and a custom User-Agent is used.
 
+### Export ads to CSV
+
+```bash
+python export_ads.py
+```
+
+The script interactively asks for a minimum/maximum price and maximum age in days
+and writes the matching active ads to `ads.csv`.
+
 ## Modules
 
 * `model.py` – Dataclass representing an ad.
@@ -43,6 +52,7 @@ the database. Requests are throttled and a custom User-Agent is used.
 * `de_dates.py` – Parse German relative dates to ISO format.
 * `rss_ingest.py` – Poll RSS feeds and store ads.
 * `enrich_playwright.py` – Enrich ads by visiting the ad page.
+* `export_ads.py` – Export filtered ads to a CSV file.
 
 ## Schema
 

--- a/export_ads.py
+++ b/export_ads.py
@@ -1,0 +1,78 @@
+"""Export active ads to a CSV file with optional filters."""
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timedelta
+from typing import Optional, List
+
+from db import get_connection, init_db
+
+
+OUTPUT_FILE = "ads.csv"
+
+
+def prompt_int(prompt: str) -> Optional[int]:
+    """Prompt user for an integer value, allowing blank for None."""
+    while True:
+        val = input(prompt).strip()
+        if not val:
+            return None
+        try:
+            return int(val)
+        except ValueError:
+            print("Please enter a valid integer or leave blank.")
+
+
+def query_ads(
+    min_price: Optional[int],
+    max_price: Optional[int],
+    max_age_days: Optional[int],
+) -> List[tuple]:
+    """Query ads table and return rows matching filters."""
+    conn = get_connection()
+    try:
+        init_db(conn)
+        sql = (
+            "SELECT title, price, location, date_posted, link "
+            "FROM ads WHERE is_active = 1"
+        )
+        params: List[object] = []
+
+        if min_price is not None:
+            sql += " AND price >= ?"
+            params.append(min_price)
+        if max_price is not None:
+            sql += " AND price <= ?"
+            params.append(max_price)
+        if max_age_days is not None:
+            cutoff = (datetime.utcnow() - timedelta(days=max_age_days)).date().isoformat()
+            sql += " AND date_posted IS NOT NULL AND date_posted >= ?"
+            params.append(cutoff)
+
+        sql += " ORDER BY date_posted DESC"
+        rows = conn.execute(sql, params).fetchall()
+        return [(r["title"], r["price"], r["location"], r["date_posted"], r["link"]) for r in rows]
+    finally:
+        conn.close()
+
+
+def write_csv(rows: List[tuple], path: str = OUTPUT_FILE) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["title", "price", "location", "date_posted", "link"])
+        writer.writerows(rows)
+
+
+def main() -> None:
+    print("Export active ads to CSV")
+    min_price = prompt_int("Minimum price (blank for none): ")
+    max_price = prompt_int("Maximum price (blank for none): ")
+    max_age_days = prompt_int("Maximum age in days (blank for any): ")
+
+    rows = query_ads(min_price, max_price, max_age_days)
+    write_csv(rows, OUTPUT_FILE)
+    print(f"Wrote {len(rows)} ads to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `export_ads.py` to interactively export active ads to CSV with optional price and age filters
- document the export script in the README

## Testing
- `python -m py_compile export_ads.py`
- `printf '\n\n\n' | python export_ads.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab593b4628832b913bf9a992fa1f19